### PR TITLE
use defonce to preserve state across figwheel refreshes

### DIFF
--- a/examples/trailing-mouse-pointer/README.md
+++ b/examples/trailing-mouse-pointer/README.md
@@ -14,6 +14,10 @@ Once these steps are done, you can start the application as usual:
 
     lein run
 
+To automatically update the application as you make changes, open another terminal:
+
+    lein figwheel
+
 Now, you can open **[http://localhost:8010/](http://localhost:8010/)** and start interacting with the application:
 
 ## License

--- a/examples/trailing-mouse-pointer/src/cljs/example/store.cljs
+++ b/examples/trailing-mouse-pointer/src/cljs/example/store.cljs
@@ -22,10 +22,13 @@
     (swap! cmp-state update-in [:server-proc-times] conj server-proc-time)
     (swap! cmp-state update-in [:network-times] conj network-time)))
 
+;; Preserve state across releads caused by Figwheel
+(defonce my-state (atom {:count 0 :rtt-times [] :network-times [] :server-proc-times []}))
+
 (defn mk-state
   "Return clean initial component state atom."
   [put-fn]
-  state)
+  my-state)
 
 (defn component
   [cmp-id]


### PR DESCRIPTION
Small change to store.cljs to preserve state. There is a commented-out print which shows this. The browser display changes, though, so other changes are necessary. 
