### PR TITLE
v0.2.18: message UUID and component sequence on message metadata

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,11 @@
+## v0.2.18 - July 27th, 2015
+
+```clojure
+[matthiasn/systems-toolbox "0.2.18"]
+```
+
+* When a message is first emitted, a UUID is attached to the metadata, which allows tracking the message on its way through the system.
+* The full sequence of components that a message passes through is recorded on the metadata.
 
 
 ## v0.2.17 - July 23rd, 2015

--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,4 @@
-## v0.2.18 - July 27th, 2015
+## v0.2.18 - July 28th, 2015
 
 ```clojure
 [matthiasn/systems-toolbox "0.2.18"]

--- a/changes.md
+++ b/changes.md
@@ -4,7 +4,7 @@
 [matthiasn/systems-toolbox "0.2.18"]
 ```
 
-* When a message is first emitted, a UUID is attached to the metadata, which allows tracking the message on its way through the system.
+* When a message is first emitted, a :tag UUID is attached to the metadata, which allows tracking a message on its way through the system. Also, a correlation UUID is attached, which uniquely marks an emitted message. 
 * The full sequence of components that a message passes through is recorded on the metadata.
 
 

--- a/examples/trailing-mouse-pointer/project.clj
+++ b/examples/trailing-mouse-pointer/project.clj
@@ -11,7 +11,7 @@
                  [hiccup-bridge "1.0.1"]
                  [garden "1.2.5"]
                  [clj-pid "0.1.1"]
-                 [matthiasn/systems-toolbox "0.2.18-SNAPSHOT"]
+                 [matthiasn/systems-toolbox "0.2.18"]
                  [reagent "0.5.0"]
                  [incanter "1.5.6"]
                  [clj-time "0.9.0"]

--- a/examples/trailing-mouse-pointer/project.clj
+++ b/examples/trailing-mouse-pointer/project.clj
@@ -11,7 +11,7 @@
                  [hiccup-bridge "1.0.1"]
                  [garden "1.2.5"]
                  [clj-pid "0.1.1"]
-                 [matthiasn/systems-toolbox "0.2.17"]
+                 [matthiasn/systems-toolbox "0.2.18-SNAPSHOT"]
                  [reagent "0.5.0"]
                  [incanter "1.5.6"]
                  [clj-time "0.9.0"]

--- a/examples/trailing-mouse-pointer/src/clj/example/core.clj
+++ b/examples/trailing-mouse-pointer/src/clj/example/core.clj
@@ -31,6 +31,8 @@
 
      ;; Then, messages of a given type are wired from one component to another.
      [:cmd/route-all {:from :server/ptr-cmp :to :server/ws-cmp}]
+     [:cmd/route-all {:from :server/ptr-cmp :to :server/log-cmp}]
+
      [:cmd/route-all {:from :server/metrics-cmp :to :server/ws-cmp}]
      [:cmd/route {:from :server/ws-cmp :to :server/ptr-cmp}]
      [:cmd/route {:from :server/scheduler-cmp :to :server/ws-cmp :only :cmd/mouse-pos}]

--- a/examples/trailing-mouse-pointer/src/clj/example/pointer.clj
+++ b/examples/trailing-mouse-pointer/src/clj/example/pointer.clj
@@ -11,7 +11,7 @@
 (defn process-mouse-pos
   "Handler function for received mouse positions, increments counter and returns mouse position to sender."
   [{:keys [cmp-state msg put-fn]}]
-  (let [[_ params] msg
+  (let [[msg-type params] msg
         d1 (Math/round (dist/draw (stats/sample-normal 1000 :mean 15 :sd 6)))
         d2 (Math/round (dist/draw (stats/sample-normal 1000 :mean 150 :sd 1)))]
     (swap! cmp-state update-in [:count] inc)

--- a/examples/trailing-mouse-pointer/src/cljs/example/core.cljs
+++ b/examples/trailing-mouse-pointer/src/cljs/example/core.cljs
@@ -26,6 +26,8 @@
 
      ;; Then, messages of a given type are wired from one component to another.
      [:cmd/route-all {:from :client/mouse-cmp :to :client/ws-cmp}]
+     [:cmd/route-all {:from :client/mouse-cmp :to :client/log-cmp}]
+     [:cmd/route-all {:from :client/ws-cmp :to :client/log-cmp}]
      [:cmd/route {:from :client/ws-cmp :to :client/store-cmp}]
      [:cmd/route {:from :client/ws-cmp :to :client/jvmstats-cmp}]
      [:cmd/observe-state {:from :client/store-cmp :to :client/histogram-cmp}]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox "0.2.18-SNAPSHOT"
+(defproject matthiasn/systems-toolbox "0.2.18"
   :description "Toolbox for building Systems in Clojure"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox "0.2.17"
+(defproject matthiasn/systems-toolbox "0.2.18-SNAPSHOT"
   :description "Toolbox for building Systems in Clojure"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"
@@ -19,6 +19,7 @@
                  [compojure "1.3.4" :exclusions [commons-codec]]
                  [ring "1.3.2"]
                  [ring/ring-defaults "0.1.5"]
+                 [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
                  [matthiasn/http-kit "2.1.19"]]
 
   :plugins [[codox "0.8.8"]

--- a/src/cljc/matthiasn/systems_toolbox/component.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/component.cljc
@@ -93,11 +93,17 @@
   It takes the initial state atom, the handler function for messages on in-chan, and the
   sliding-handler function, which handles messages on sliding-in-chan.
   By default, in-chan and out-chan have standard buffers of size one, whereas sliding-in-chan
-  and sliding-out-chan have sliding buffers of size one.
-  The buffer sizes can be configured.
+  and sliding-out-chan have sliding buffers of size one. The buffer sizes can be configured.
   The sliding-channels are meant for events where only ever the latest version is of interest,
   such as mouse moves or published state snapshots in the case of UI components rendering
-  state snapshots from other components."
+  state snapshots from other components.
+  Components send messages by using the put-fn, which is provided to the component when
+  creating it's initial state, and then subsequently in every call to any of the handler
+  functions. On every message send, a unique correlation ID is attached to every message.
+  Also, messages are automatically assigned a tag, which is a unique ID that doesn't change
+  when a message flows through the system. This tag can also be assigned manually by
+  initially sending a message with the tag set on the metadata, as this tag will not be
+  touched by the library whenever it exists already."
   [{:keys [cmp-id state-fn snapshot-xform-fn opts] :as cmp-conf}]
   (let [cfg (merge component-defaults opts)
         out-chan (make-chan-w-buf (:out-chan cfg))

--- a/src/cljc/matthiasn/systems_toolbox/component.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/component.cljc
@@ -108,10 +108,9 @@
                  (let [msg-meta (-> (merge (meta msg) {})
                                     (add-to-msg-seq cmp-id)
                                     (assoc-in [cmp-id :out-ts] (now)))
-                       msg-uuid (uuid)
-                       corr-uuid (or (:corr-uuid msg-meta) (uuid))
-                       msg-w-meta (with-meta msg (merge msg-meta {:corr-uuid corr-uuid
-                                                                  :msg-uuid msg-uuid}))]
+                       corr-id (uuid)
+                       tag (or (:tag msg-meta) (uuid))
+                       msg-w-meta (with-meta msg (merge msg-meta {:corr-id corr-id :tag tag}))]
                    (put! out-chan msg-w-meta)
                    (when (:msgs-on-firehose cfg)
                      (put! firehose-chan [:firehose/cmp-put {:cmp-id cmp-id :msg msg-w-meta}]))))


### PR DESCRIPTION
In this commit, UUIDs are added to the component metadata when a message is first
created. This allows for better tracking of the message traversing the system.
Also, the sequence of components handling a message is recorded.

The effects of this change can be seen in the example application, where some
messages routes are printed to the browser console or the terminal for the backend
application. I was undecided about the best way to record the sequence, so I created
two different formats. Try it out and let me know what you think. You'll need to
install the systems-toolbox locally for now as this WIP isn't published yet.
