### PR TITLE
Add support for React lifecycle callbacks such as :component-will-update.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,11 @@
+## v0.2.19
+
+```clojure
+[matthiasn/systems-toolbox "0.2.19"]
+```
+
+* Reagent components now support :lifecycle-callbacks parameter that can be used to attach React components' lifecycle methods such as :component-will-update.
+
 ## v0.2.18 - July 28th, 2015
 
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox "0.2.18"
+(defproject matthiasn/systems-toolbox "0.2.19-SNAPSHOT"
   :description "Toolbox for building Systems in Clojure"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"

--- a/src/cljs/matthiasn/systems_toolbox/reagent.cljs
+++ b/src/cljs/matthiasn/systems_toolbox/reagent.cljs
@@ -1,21 +1,22 @@
 (ns matthiasn.systems-toolbox.reagent
-  (:require [reagent.core :as r :refer [atom]]
+  (:require [reagent.core :as r :refer [create-class atom]]
             [matthiasn.systems-toolbox.component :as comp]
             [matthiasn.systems-toolbox.helpers :refer [by-id]]))
 
 (defn init
   "Return clean initial component state atom."
-  [view-fn dom-id init-state init-fn put-fn]
+  [reagent-cmp-map dom-id init-state init-fn put-fn]
   (let [local (if init-state
                 (atom init-state)
                 (atom {}))
         observed (atom {})
         cmd (fn ([& r] (fn [e] (.stopPropagation e) (put-fn (vec r)))))
+        reagent-cmp (create-class reagent-cmp-map)
         view-cmp-map {:observed observed
                       :local    local
                       :put-fn   put-fn
                       :cmd      cmd}]
-    (r/render-component [view-fn view-cmp-map] (by-id dom-id))
+    (r/render-component [reagent-cmp view-cmp-map] (by-id dom-id))
     (when init-fn (init-fn view-cmp-map))
     {:local local :observed observed}))
 
@@ -25,8 +26,9 @@
   (reset! (:observed cmp-state) msg-payload))
 
 (defn component
-  [{:keys [cmp-id view-fn dom-id initial-state init-fn cfg handler-map]}]
-  (let [mk-state (partial init view-fn dom-id initial-state init-fn)]
+  [{:keys [cmp-id view-fn lifecycle-callbacks dom-id initial-state init-fn cfg handler-map]}]
+  (let [reagent-cmp-map (merge lifecycle-callbacks {:reagent-render view-fn})
+        mk-state (partial init reagent-cmp-map dom-id initial-state init-fn)]
     (comp/make-component {:cmp-id            cmp-id
                           :state-fn          mk-state
                           :handler-map       handler-map


### PR DESCRIPTION
Usage:

``` clojure
(defn save-scroll-status
  "Before component re-renders, stores a flag whether messages window was scrolled to the bottom."
  [_ [_ {:keys [local]}]]
  (swap! local assoc :scrolled-to-the-bottom (is-element-scrolled-down? (by-id "messages"))))

(defn scroll-if-needed
  "If a flag is set, scrolls to the bottom."
  [_ [_ {:keys [local]}]]
  (if (:scrolled-to-the-bottom @local)
         (scroll-to-the-bottom (by-id "messages"))))

(defn component
  [cmp-id]
  (r/component {:cmp-id      cmp-id
                :view-fn     view-fn
                :lifecycle-callbacks {:component-will-update save-scroll-status
                                      :component-did-update scroll-if-needed}
                :dom-id      container-dom-id}))
```

As you can see first parameter is not used - it's React's props object. Second parameters second element is the state I'm interested in. I left those unneeded ones for two reasons: impl is then trivial and this is the way it works in Reagent, so developers will be probably expecting that set of arguments.
