### PR TITLE
Warn user when using (run-handler) incorrectly.

### DIFF
--- a/src/cljc/matthiasn/systems_toolbox/handler_utils.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/handler_utils.cljc
@@ -1,6 +1,7 @@
 (ns matthiasn.systems-toolbox.handler-utils
   #?(:clj
-     (:gen-class)))
+     (:gen-class))
+  (:require [clojure.set :refer [subset?]]))
 
 (defn fwd-as
   "Creates a handler function that sends the payload of handled message as a new message type while discarding
@@ -18,6 +19,11 @@
                                                  :msg-payload msg-payload
                                                  :msg [handler-key msg-payload])))))
   ([handler-key msg-map]
+   ;; A common mistake is to call (run-handler) with a handler-key and msg-payload, but not with
+   ;; a msg-map. In such case, this fn would do nothing and fail silently, leaving user in a blank.
+   ;; Assert to verify against that.
+   (assert (subset? #{:cmp-state :msg-meta :msg-payload} (into #{} (keys msg-map)))
+           "(run-handler) invoked with invalid arguments. Make sure you did pass msg-map.")
    (let [handler-fn (handler-key (:handler-map msg-map))]
      (when handler-fn (handler-fn (assoc msg-map :msg-type handler-key
                                                  :msg [handler-key]))))))


### PR DESCRIPTION
Hey @matthiasn. It has happened to me several times already, that I'd run `(run-handler)`, but forget to pass in the msg-map. It all looks good when looing at the code, but nothing happens, such a mistake doesn't cause any error or warning to occur.  So I figured a simple assert here would be nice.
