### PR TITLE
Add a missing core.match reference.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox "0.5.3"
+(defproject matthiasn/systems-toolbox "0.5.6"
   :description "Toolbox for building Systems in Clojure"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"
@@ -9,6 +9,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.reader "1.0.0-alpha1"]
                  [org.clojure/clojurescript "1.7.228"]
+                 [org.clojure/core.match "0.3.0-alpha4"]
                  [org.ow2.asm/asm-all "5.0.4"]
                  [org.clojure/core.async "0.2.374" :exclusions [org.clojure/tools.reader]]
                  [org.clojure/tools.logging "0.3.1"]


### PR DESCRIPTION
There was a missing dependency on `core.match`. Plus a last released version was 0.5.5, and here it was 0.5.3. Not sure why, but bumped to 0.5.6.
