### PR TITLE
Not fire a scheduled message if was cancelled before.

### DIFF
--- a/src/cljc/matthiasn/systems_toolbox/scheduler.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/scheduler.cljc
@@ -45,15 +45,15 @@
       (when (:initial msg-payload) (put-fn msg-to-send))
       (go-loop []
         (<! (timeout timout-ms))
-        (let [active-timer (get-in @cmp-state [:active-timers scheduler-id])]
-          (put-fn msg-to-send)
-          (if active-timer
+        (if-let [active-timer (get-in @cmp-state [:active-timers scheduler-id])]
+          (do
+            (put-fn msg-to-send)
             (if (:repeat active-timer)
               (recur)
               (do
                 (swap! cmp-state update :active-timers dissoc scheduler-id)
-                (put-fn [:info/completed-timer scheduler-id])))
-            (put-fn [:info/deleted-timer scheduler-id])))))))
+                (put-fn [:info/completed-timer scheduler-id]))))
+          (put-fn [:info/deleted-timer scheduler-id]))))))
 
 (defn stop-loop
   "Stops a an loop that was previously scheduled."


### PR DESCRIPTION
Hey,
when you schedule a message to be fired in say 10 seconds, but cancel it prior to that time (i.e. after 5 seconds), the message would still get fired. This simple change fixes that.

(need that on 0.5.x unfortunately, however scheduler component doesn't seem to have changed significantly so conflicts shouldn't be an issue)