### PR TITLE
Make switchboard's spec validation be configurable.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject matthiasn/systems-toolbox "0.6.8"
+(defproject matthiasn/systems-toolbox "0.6.9"
   :description "Toolbox for building Systems in Clojure"
   :url "https://github.com/matthiasn/systems-toolbox"
   :license {:name "Eclipse Public License"
@@ -26,7 +26,7 @@
 
   :test-refresh {:notify-on-success false
                  :changes-only      false}
-  
+
   :test-paths ["test"]
   ;:test-paths ["dev-resources" "test" "perf"]
 

--- a/src/cljc/matthiasn/systems_toolbox/switchboard.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/switchboard.cljc
@@ -87,18 +87,21 @@
 (defn component
   "Creates a switchboard component that wires individual components together
    into a communicating system."
-  [switchboard-id]
-  (let [switchboard (comp/make-component
-                      {:cmp-id            switchboard-id
-                       :state-fn          mk-state
-                       :handler-map       handler-map
-                       :state-spec        :st.switchboard/state-spec
-                       :opts              {:msgs-on-firehose      false
-                                           :snapshots-on-firehose true}
-                       :snapshot-xform-fn xform-fn})
-        sw-in-chan (:in-chan switchboard)]
-    (put! sw-in-chan [:cmd/self-register switchboard])
-    switchboard))
+  ([switchboard-id]
+   (component switchboard-id {}))
+  ([switchboard-id cmp-opts]
+   (let [switchboard (comp/make-component
+                       {:cmp-id            switchboard-id
+                        :state-fn          mk-state
+                        :handler-map       handler-map
+                        :state-spec        :st.switchboard/state-spec
+                        :opts              (merge {:msgs-on-firehose false
+                                                   :snapshots-on-firehose true}
+                                                  cmp-opts)
+                        :snapshot-xform-fn xform-fn})
+         sw-in-chan (:in-chan switchboard)]
+     (put! sw-in-chan [:cmd/self-register switchboard])
+     switchboard)))
 
 (defn send-cmd
   "Send message to the specified switchboard component."


### PR DESCRIPTION
I noticed that after the recent upgrade of systems-toolbox, a lot of time on the first load is being spent doing spec validation. It turns out switchboard has `:validate-out` and `:validate-spec` turned on (because it's the default setting for a component). It's currently not possible to override it, hence this PR.

We have a lot of components, as you know, and this costs us approx. 500 ms on the first load - and that is with code compiled in advanced mode.