### PR TITLE
Component-specific atom watch reference.

### DIFF
--- a/src/cljc/matthiasn/systems_toolbox/component.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/component.cljc
@@ -55,8 +55,8 @@
    the 'snapshot-publish-fn'."
   [{:keys [watch-state cmp-id snapshot-publish-fn]}]
   (try
-    (add-watch watch-state :watcher (fn [_ _ _ _new-state]
-                                      (snapshot-publish-fn)))
+    (add-watch watch-state cmp-id (fn [_ _ _ _new-state]
+                                    (snapshot-publish-fn)))
     #?(:clj  (catch Exception e
                (l/error "Failed watching atom" cmp-id
                         (ex/format-exception e)


### PR DESCRIPTION
Hey @matthiasn!

I recently entertained the idea of using multiple state components with a single state atom. Idea is essentially this:

- `defonce` an atom in a single place (like re-frame does)
- create as many state components as needed (one per each distinct piece of business logic)
- in each of those state components, use this `state-fn`: `(constantly {:state db/state})`, where `db/state` is the state atom.

My reasons behind this is that one large state component tends to use `:send-to-self` way too often. It's:

- confusing (i.e. hard to know when to use `:emit-msg` and when `:send-to-self` unless I stop for a second and think where the destination of the command is specified)
- non-inspectable (i.e. such commands don't end up on the firehose) 
- no meta support

(I believe we actually discussed those reasons in the past)

**Now to the point** - all works well with the approach I described, but if I return a single atom from `state-fn` in multiple components, the `:watcher` reference from `add-watch` will keep only the last watcher active. So modifying state will trigger state publish command being sent only from one component out of many that are possibly using the same atom.

Solution is simple I think - just use component ID as watch reference, instead of the fixed `:watcher` kw.