### PR TITLE
Make UUID's pass uuid? predicate.

### DIFF
--- a/src/cljc/matthiasn/systems_toolbox/component/helpers.cljc
+++ b/src/cljc/matthiasn/systems_toolbox/component/helpers.cljc
@@ -15,8 +15,8 @@
 (defn make-uuid
   "Get a random UUID."
   []
-  #?(:clj  (str (java.util.UUID/randomUUID))
-     :cljs (str (uuid/make-random-uuid))))
+  #?(:clj  (java.util.UUID/randomUUID)
+     :cljs (uuid/make-random-uuid)))
 
 #?(:cljs (def request-animation-frame
            (or (when (exists? js/window)


### PR DESCRIPTION
Hey!
It would be useful it `:corr-id` and `:tag` passed `uuid?` predicate.  I don't see any reason to wrap those with `str`. Mabe it was related to some serialization issues when sending over commands to the backend?